### PR TITLE
fixind for atmega128(l/a) and other old board

### DIFF
--- a/include/avr/power.h
+++ b/include/avr/power.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2006, 2007, 2008  Eric B. Weddington
-   Copyright (c) 2011 Frédéric Nadeau
+   Copyright (c) 2011 FrÃ©dÃ©ric Nadeau
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -61,7 +61,7 @@ find out which macros are applicable to your device.
 
 \note For device using the XTAL Divide Control Register (XDIV), when prescaler
 is used, Timer/Counter0 can only be used in asynchronous mode. Keep in mind
-that Timer/Counter0 source shall be less than ¼th of peripheral clock.
+that Timer/Counter0 source shall be less than Â¼th of peripheral clock.
 Therefore, when using a typical 32.768 kHz crystal, one shall not scale
 the clock below 131.072 kHz.
 
@@ -3211,7 +3211,12 @@ void clock_prescale_set(clock_div_t __x)
 }
 
 /** \addtogroup avr_power
-\code clock_prescale_get() \endcode
+\code 
+
+
+
+
+() \endcode
 Gets and returns the clock prescaler register setting. The return type is \c clock_div_t.
 
 \note For device with XTAL Divide Control Register (XDIV), return can actually
@@ -3666,7 +3671,7 @@ clock_div_t clock_prescale_get(void)
 {
     if(bit_is_clear(XDIV, XDIVEN))
     {
-        return 1;
+        return (clock_div_t)1;
     }
     else
     {


### PR DESCRIPTION
fix error of #include <avr/power.h> for Arduino IDE for boards ATmega64, ATmega103, ATmega128.
(used with MegaCore lib)